### PR TITLE
Sanitizzle Inputizzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ can be installed as:
       [
         {:websocket_client, github: "jeremyong/websocket_client"},
         {:alice, "~> 0.2.0"},
-        {:alice_shizzle, "~> 0.1.0"}
+        {:alice_shizzle, "~> 0.1.1"}
       ]
     end
     ```

--- a/lib/alice/handlers/shizzle.ex
+++ b/lib/alice/handlers/shizzle.ex
@@ -1,10 +1,6 @@
 defmodule Alice.Handlers.Shizzle do
   use Alice.Router
 
-  @slack_url_pattern ~r/\<([^|]+)(.*)?>/
-  @slack_email_pattern ~r/\<mailto:([^|]+)(.*)?>/
-  @slack_username_pattern ~r/\<@([^|]+)>/
-
   command ~r/\bshizzle\s+me (?<term>.+)/i, :tranzizzle
   route   ~r/\Ashizzle\s+me (?<term>.+)/i, :tranzizzle
   command ~r/\bshizzle\s+url (?<term>.+)/i, :querizzle
@@ -18,58 +14,44 @@ defmodule Alice.Handlers.Shizzle do
   @doc "`shizzle url ____` - link ta a tranzizzled url or search term"
   def querizzle(connizzle),  do: handizzle(connizzle, :querizzle)
 
-  def handizzle(connizzle, name) do
+  defp handizzle(connizzle, name) do
     connizzle
     |> extract_dat_term
-    |> santizzle(connizzle)
+    |> sanitizzle
     |> shizzlize(name)
+    |> unhide_yo_usernames
     |> reply(connizzle)
   end
 
-  def extract_dat_term(connizzle) do
+  defp extract_dat_term(connizzle) do
     connizzle.message.captures
     |> Enum.reverse
     |> hd
   end
 
-  def shizzlize(text, :tranzizzle), do: text |> Gizoogle.translate
-  def shizzlize(text, :querizzle),  do: text |> Gizoogle.url
+  defp shizzlize(text, :tranzizzle), do: text |> Gizoogle.translate
+  defp shizzlize(text, :querizzle),  do: text |> Gizoogle.url
 
-  def santizzle(text, connizzle) do
+  def sanitizzle(text) do
     text
-    |> santizzle_punctuations
-    |> santizzle_urls
-    |> santizzle_emails
-    # |> santizzle_usernames(connizzle)
+    |> hide_yo_punctuations
+    |> hide_yo_emails
+    |> hide_yo_usernames
+    |> hide_yo_urls
   end
 
-  def santizzle_punctuations(text) do
+  defp hide_yo_punctuations(text) do
     text
-    |> String.replace("“", "\"")
-    |> String.replace("”", "\"")
-    |> String.replace("’", "'")
+    |> String.replace("“", ~s("))
+    |> String.replace("”", ~s("))
+    |> String.replace("’", ~s('))
   end
 
-  def santizzle_urls(text), do: text |> String.replace(@slack_url_pattern, "\\1")
+  defp hide_yo_emails(text), do: text |> String.replace(~r/<mailto:([^|]+)[^\s]*>/i, "\\1")
 
-  def santizzle_emails(text), do: text |> String.replace(@slack_email_pattern, "\\1")
+  defp hide_yo_urls(text), do: text |> String.replace(~r/<([^|@]+)([^\s]*)?>/, "\\1")
 
-  # def santizzle_usernames(text, connizzle), do: text |> String.replace(@slack_username_pattern, retreive_username("\\1", connizzle))
+  defp hide_yo_usernames(text), do: text |> String.replace(~r/<(@[\w\d]+)>/, "#:#\\1#:#")
 
-  # def retreive_username(username_code, connizzle) do
-  #   connizzle.slack.users[username_code].name
-  # end
-
-  # def something(text, connizzle) do
-  #   ~r/<@(.*?)>/
-  #   |> Regex.scan(text)
-  #   |> Enum.uniq
-  #   |> something_else(text)
-  # end
-
-  # def something_else([], text)
-
-  # def something_else([[matcher, match]|tail], text) do
-    
-  # end
+  def unhide_yo_usernames(text), do: text |> String.replace(~r/#:#(@[\w\d]+)#:#/, "<\\1>")
 end

--- a/lib/alice/handlers/shizzle.ex
+++ b/lib/alice/handlers/shizzle.ex
@@ -1,7 +1,9 @@
 defmodule Alice.Handlers.Shizzle do
   use Alice.Router
 
-  @slack_url_pattern ~r/\A<([^|]+)(.*)?>\z/
+  @slack_url_pattern ~r/\<([^|]+)(.*)?>/
+  @slack_email_pattern ~r/\<mailto:([^|]+)(.*)?>/
+  @slack_username_pattern ~r/\<@([^|]+)>/
 
   command ~r/\bshizzle\s+me (?<term>.+)/i, :tranzizzle
   route   ~r/\Ashizzle\s+me (?<term>.+)/i, :tranzizzle
@@ -9,26 +11,65 @@ defmodule Alice.Handlers.Shizzle do
   route   ~r/\Ashizzle\s+url (?<term>.+)/i, :querizzle
 
   @doc "`shizzle me ____` - drop a rhyme like a thug"
-  def tranzizzle(connizzle), do: handizzle(connizzle, :tranzizzle)
+  def tranzizzle(connizzle) do
+    handizzle(connizzle, :tranzizzle)
+  end
 
   @doc "`shizzle url ____` - link ta a tranzizzled url or search term"
   def querizzle(connizzle),  do: handizzle(connizzle, :querizzle)
 
-  defp handizzle(connizzle, name) do
+  def handizzle(connizzle, name) do
     connizzle
     |> extract_dat_term
+    |> santizzle(connizzle)
     |> shizzlize(name)
     |> reply(connizzle)
   end
 
-  defp extract_dat_term(connizzle) do
+  def extract_dat_term(connizzle) do
     connizzle.message.captures
     |> Enum.reverse
     |> hd
   end
 
-  defp shizzlize(text, :tranzizzle), do: text |> Gizoogle.translate
-  defp shizzlize(text, :querizzle),  do: text |> santizzle_url |> Gizoogle.url
+  def shizzlize(text, :tranzizzle), do: text |> Gizoogle.translate
+  def shizzlize(text, :querizzle),  do: text |> Gizoogle.url
 
-  defp santizzle_url(url), do: url |> String.replace(@slack_url_pattern, "\\1")
+  def santizzle(text, connizzle) do
+    text
+    |> santizzle_punctuations
+    |> santizzle_urls
+    |> santizzle_emails
+    # |> santizzle_usernames(connizzle)
+  end
+
+  def santizzle_punctuations(text) do
+    text
+    |> String.replace("“", "\"")
+    |> String.replace("”", "\"")
+    |> String.replace("’", "'")
+  end
+
+  def santizzle_urls(text), do: text |> String.replace(@slack_url_pattern, "\\1")
+
+  def santizzle_emails(text), do: text |> String.replace(@slack_email_pattern, "\\1")
+
+  # def santizzle_usernames(text, connizzle), do: text |> String.replace(@slack_username_pattern, retreive_username("\\1", connizzle))
+
+  # def retreive_username(username_code, connizzle) do
+  #   connizzle.slack.users[username_code].name
+  # end
+
+  # def something(text, connizzle) do
+  #   ~r/<@(.*?)>/
+  #   |> Regex.scan(text)
+  #   |> Enum.uniq
+  #   |> something_else(text)
+  # end
+
+  # def something_else([], text)
+
+  # def something_else([[matcher, match]|tail], text) do
+    
+  # end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule AliceShizzle.Mixfile do
 
   def project do
     [app: :alice_shizzle,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/alice/handler/shizzle_test.exs
+++ b/test/alice/handler/shizzle_test.exs
@@ -1,0 +1,39 @@
+defmodule Alice.Handlers.ShizzleTest do
+  use ExUnit.Case, async: true
+
+  alias Alice.Handlers.Shizzle
+
+  test "sanitizzle sanitizes jive-ass quotes" do
+    assert Shizzle.sanitizzle("“”’") == ~s(""')
+  end
+
+  test "sanitizzle sanitizes punk-ass urls" do
+    url_string = "I go to <http://cnn.com|cnn.com> for my news!"
+    clean_string = "I go to http://cnn.com for my news!"
+    assert Shizzle.sanitizzle(url_string) == clean_string
+  end
+
+  test "sanitizzle sanitizes dusty-ass emails" do
+    email_string = "I email all me kitten gifs to <mailto:user@example.com|user@example.com>!"
+    clean_string = "I email all me kitten gifs to user@example.com!"
+    assert Shizzle.sanitizzle(email_string) == clean_string
+  end
+
+  test "sanitizzle sanitizes ratchet-ass usernames" do
+    username_string = "yo <@U02EGPSD3>"
+    clean_string = "yo #:#@U02EGPSD3#:#"
+    assert Shizzle.sanitizzle(username_string) == clean_string
+  end
+
+  test "unhide_yo_usernames unsanitizes ratchet-ass usernames" do
+    username_string = "yo <@U02EGPSD3>"
+    clean_string = "yo #:#@U02EGPSD3#:#"
+    assert Shizzle.unhide_yo_usernames(clean_string) == username_string
+  end
+
+  test "errrrrthing works" do
+    big_ass_string = "<@U02EGPSD3>’s <http://CNN.com|CNN.com> email address is <mailto:user@example.com|user@example.com> and don’t you “forget” it dude! Email <@U025Q5H6D> here, at <http://CNN.com|CNN.com>"
+    clean_ass_string = ~s(<@U02EGPSD3>'s http://CNN.com email address is user@example.com and don't you "forget" it dude! Email <@U025Q5H6D> here, at http://CNN.com)
+    assert clean_ass_string == (big_ass_string |> Shizzle.sanitizzle |> Shizzle.unhide_yo_usernames)
+  end
+end


### PR DESCRIPTION
Slack chizzlez usernames, emails, urls, n' double n' single quotes so
dat it is thugged-out ta slack. This causes problems when bustin
thangs ta gizoogle n' retrievin dem back all up in tha xml. I have
added sanitizers now dat properly handle tha weird thangs dat slack do
so dat we can translate n' parse thangs properly n' then bust dem back
ta slack safely.

Fixes #3 
